### PR TITLE
Switch to use a pointer for parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     uri-whatwg_parser (0.1.2)
-      strscan
       uri
       uri-idna
 
@@ -33,7 +32,6 @@ GEM
     reline (0.6.1)
       io-console (~> 0.5)
     stringio (3.1.7)
-    strscan (3.1.5)
     test-unit (3.6.8)
       power_assert
     uri (1.0.3)

--- a/benchmark/strscan.rb
+++ b/benchmark/strscan.rb
@@ -1,0 +1,22 @@
+require "benchmark/ips"
+require "uri/whatwg_parser"
+
+whatwg_parser = URI::WhatwgParser.new
+$VERBOSE = nil
+
+condition = ""
+if ENV["USE_STRSCAN"] == 'true'
+  condition += " with strscan"
+end
+if RubyVM::YJIT.enabled?
+  condition += " with YJIT"
+end
+
+Benchmark.ips do |x|
+  x.report("parse #{condition}") do
+    URI.parse("http://www.ruby-lang.org/")
+  end
+
+  x.save!('/tmp/whatg_parse-benchmark')
+  x.compare!
+end

--- a/uri-whatwg_parser.gemspec
+++ b/uri-whatwg_parser.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "strscan"
   spec.add_dependency "uri"
   spec.add_dependency "uri-idna"
   spec.add_development_dependency "debug"


### PR DESCRIPTION
It seems that this approach is faster.

```ruby
require "benchmark/ips"
require "uri/whatwg_parser"

whatwg_parser = URI::WhatwgParser.new
$VERBOSE = nil

condition = ""
if ENV["USE_STRSCAN"] == 'true'
  condition += " with strscan"
end
if RubyVM::YJIT.enabled?
  condition += " with YJIT"
end

Benchmark.ips do |x|
  x.report("parse #{condition}") do
    URI.parse("http://www.ruby-lang.org/")
  end

  x.save!('/tmp/whatg_parse-benchmark')
  x.compare!
end
```

```
Comparison:
    parse  with YJIT:    18353.7 i/s
parse  with strscan with YJIT:    16413.3 i/s - 1.12x  slower
              parse :    11089.0 i/s - 1.66x  slower
 parse  with strscan:    10339.6 i/s - 1.78x  slower
```